### PR TITLE
Fix progressBar setValue crash when passing float values

### DIFF
--- a/crs_guesser.py
+++ b/crs_guesser.py
@@ -249,7 +249,7 @@ class CRSguesser:
                         count +=1
                         # Progress
                         progress_count += progress_count_plus
-                        self.dlg.progressBar.setValue(progress_count)
+                        self.dlg.progressBar.setValue(int(progress_count))
                         
                     Konvertierte_Koordinaten.close()
                     KBS_list.close()
@@ -339,7 +339,7 @@ class CRSguesser:
                 count +=1
                 # Progress
                 progress_count += progress_count_plus
-                self.dlg.progressBar.setValue(progress_count)
+                self.dlg.progressBar.setValue(int(progress_count))
             QgsProject.instance().addMapLayer(vl)
             
         #wenn keine checkbox


### PR DESCRIPTION
The Qt ProgressBar::setValue() method expects integers and passing floats
causes a crash in more recent versions of QGIS (I'm on 3.41). Casting the value to an integer makes sure this doesn't happen.